### PR TITLE
Fix submit and delete logic in Form.js - Bug #187

### DIFF
--- a/phprojekt/application/Default/Views/dojo/scripts/Form.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/Form.js
@@ -814,14 +814,16 @@ dojo.declare("phpr.Default.Form", phpr.Default.System.Component, {
             return false;
         }
 
+        var pid = phpr.currentProjectId;
+
         phpr.send({
             url: phpr.webpath + 'index.php/' + phpr.module +
-                '/index/jsonSave/nodeId/' + phpr.currentProjectId +
+                '/index/jsonSave/nodeId/' + pid +
                 '/id/' + this.id,
             content:   this.sendData,
             onSuccess: dojo.hitch(this, function(data) {
                 new phpr.handleResponse('serverFeedback', data);
-                if (!this.id) {
+                if (data.id) {
                     this.id = data.id;
                 }
                 if (data.type == 'success') {
@@ -837,12 +839,13 @@ dojo.declare("phpr.Default.Form", phpr.Default.System.Component, {
                                 this.publish("updateCacheData");
                                 // reload the page and trigger the form load
                                 phpr.pageManager.changeState({
-                                    moduleName: phpr.module
-                                });
-                                phpr.pageManager.changeState({
-                                    moduleName: phpr.module,
-                                    id: this.id
-                                });
+                                        moduleName: phpr.module,
+                                        id: this.id,
+                                        projectId: pid
+                                    }, {
+                                        forceModuleReload: true
+                                    }
+                                );
                             }
                         })
                     });
@@ -856,6 +859,9 @@ dojo.declare("phpr.Default.Form", phpr.Default.System.Component, {
         //    This function is responsible for deleting a dojo element
         // Description:
         //    This function calls jsonDeleteAction
+
+        var pid = phpr.currentProjectId;
+
         phpr.send({
             url:       phpr.webpath + 'index.php/' + phpr.module + '/index/jsonDelete/id/' + this.id,
             onSuccess: dojo.hitch(this, function(data) {
@@ -868,13 +874,10 @@ dojo.declare("phpr.Default.Form", phpr.Default.System.Component, {
                             new phpr.handleResponse('serverFeedback', data);
                             if (data.type == 'success') {
                                 this.publish("updateCacheData");
-                                // reload the page and trigger the form load
-                                phpr.pageManager.changeState({
-                                    moduleName: phpr.module
-                                });
+                                // reload the page
                                 phpr.pageManager.changeState({
                                     moduleName: phpr.module,
-                                    id: this.id
+                                    projectId: pid
                                 });
                             }
                         })

--- a/phprojekt/application/Default/Views/dojo/scripts/Main.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/Main.js
@@ -704,6 +704,8 @@ dojo.declare("phpr.Default.Main", phpr.Default.System.Component, {
     cleanPage: function() {
         // Summary:
         //     Clean the submodule div and destroy all the buttons
+        this.destroyForm();
+        this.destroyGrid();
         this.destroySearchEvent();
         var view = phpr.viewManager.getView();
         view.clearButtonRow();
@@ -831,6 +833,7 @@ dojo.declare("phpr.Default.Main", phpr.Default.System.Component, {
         //     current Module
         phpr.pageManager.changeState({
             moduleName: phpr.module,
+            projectId: phpr.currentProjectId,
             id: 0
         });
     },

--- a/phprojekt/application/Default/Views/dojo/scripts/Main.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/Main.js
@@ -706,8 +706,9 @@ dojo.declare("phpr.Default.Main", phpr.Default.System.Component, {
         //     Clean the submodule div and destroy all the buttons
         this.destroySearchEvent();
         var view = phpr.viewManager.getView();
-        view.buttonRow.destroyDescendants();;
-        view.subModuleNavigation.destroyDescendants();;
+        view.clearButtonRow();
+        view.clearRightButtonRow();
+        view.clearSubModuleNavigation();
         this.garbageCollector.collect();
 
         var globalModules = phpr.DataStore.getData({url: phpr.globalModuleUrl});

--- a/phprojekt/application/Default/Views/dojo/scripts/Main.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/Main.js
@@ -864,6 +864,9 @@ dojo.declare("phpr.Default.Main", phpr.Default.System.Component, {
                 window.clearTimeout(window.mytimeout);
             }
             this.hideSuggest();
+            var words = phpr.viewManager.getView().searchfield.get('value');
+            phpr.pageManager.getActiveModule().clickResult("search");
+            phpr.pageManager.changeState({search: words});
         } else if (phpr.isValidInputKey(key)) {
             if (window.mytimeout) {
                 window.clearTimeout(window.mytimeout);

--- a/phprojekt/application/Default/Views/dojo/scripts/system/PageManager.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/system/PageManager.js
@@ -44,7 +44,8 @@ dojo.declare("phpr.Default.System.PageManager", null, {
         this._modules[module.module] = module;
     },
 
-    changeState: function(config) {
+    changeState: function(config, options) {
+        options = options || {};
         // Summary:
         //      This function changes the page hash, and loads the new module
         // Description:
@@ -53,13 +54,15 @@ dojo.declare("phpr.Default.System.PageManager", null, {
         //      The config is a javascrip object describing the state of the
         //      page we are going to change to, there could be custom parameters
         //      but the most important ones are:
-        //      projectId, moduleName, action, id
-        if(!config.moduleName) {
+        //          projectId, moduleName, action, id
+        //      The options object can contain the following keys:
+        //          forceModuleReload
+        if (!config.moduleName) {
             config.moduleName = (this.getActiveModule() ? this.getActiveModule().module : this._defaultModule);
         }
 
         if (this.getModule(config.moduleName)) {
-            this._changeModule(config);
+            this._changeModule(config, options);
         } else {
             throw new Error("Invalid name provided: " + config.moduleName);
         }
@@ -86,7 +89,7 @@ dojo.declare("phpr.Default.System.PageManager", null, {
         }
     },
 
-    _changeModule: function(config) {
+    _changeModule: function(config, options) {
         // Submodule handling is not functional yet
         // TODO: refactor submodules to be real child of their parents
         if (this._activeModule &&
@@ -104,7 +107,9 @@ dojo.declare("phpr.Default.System.PageManager", null, {
             phpr.garbageCollector.collect();
         }
 
-        this._setHash(config);
+        if (options.omitHistoryItem !== true) {
+            this._setHash(config);
+        }
 
         var module = config.moduleName;
 
@@ -136,9 +141,13 @@ dojo.declare("phpr.Default.System.PageManager", null, {
             phpr.currentProjectId = phpr.rootProjectId;
         }
 
+        if (options.forceModuleReload === true) {
+            this._reloadModule(module);
+        }
+
         if ("undefined" != typeof config.id) {
             // If is an id, open a form
-            if (module && (config.id > 0 || config.id === 0)) {
+            if (module && (config.id > 0 || config.id === "0" || config.id === 0)) {
                 if (module !== oldmodule || newProject) {
                     this._reloadModule(module);
                 }

--- a/phprojekt/application/Default/Views/dojo/scripts/system/ViewManager.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/system/ViewManager.js
@@ -324,6 +324,15 @@ dojo.declare("phpr.Default.System.DefaultView", phpr.Default.System.View, {
                 webpath: phpr.webpath,
                 currentModule: phpr.module
             });
+    },
+    clearButtonRow: function() {
+        this.buttonRow.destroyDescendants();
+    },
+    clearRightButtonRow: function() {
+        this.rightButtonRow.destroyDescendants();
+    },
+    clearSubModuleNavigation: function() {
+        this.subModuleNavigation.destroyDescendants();
     }
 });
 


### PR DESCRIPTION
the old logic triggered the following chain:
updateCacheData,
Module reload =>
    template rerendering (removed the old form from the DOM)
(on the old form object) getFormData =>
    try to render in the (already destroyed) details container

the new flow works like that:
Module reload =>
    rerender all relevant page parts
Module openForm(id) =>
    trigger the Module to open the appropriate form with our id
        this will also delete the old form object trough Main's preOpenForm function
