### PR TITLE
Don't hang when an unknown module is saved as last location

### DIFF
--- a/phprojekt/application/Default/Controllers/JsController.php
+++ b/phprojekt/application/Default/Controllers/JsController.php
@@ -98,7 +98,16 @@ class JsController extends IndexController
                     phpr.DefaultModule    = "Project";
                     phpr.viewManager      = new phpr.Default.System.ViewManager();
                     phpr.pageManager      = new phpr.Default.System.PageManager();
+                    var availableModules = [';
+        $module = new Phprojekt_Module_Module();
+        foreach ($module->fetchAll() as $m) {
+            $scripttext .= "'{$m->name}', ";
+        }
+        $scripttext .= '];
                     phpr.module           = phpr.pageManager.getConfigFromWindow().moduleName;
+                    if (dojo.indexOf(availableModules, phpr.module) == -1) {
+                        phpr.module       = "Project";
+                    }
                     phpr.submodule        = null;
                     phpr.rootProjectId    = rootProjectId;
                     phpr.currentProjectId = rootProjectId ;

--- a/phprojekt/application/Default/Controllers/JsController.php
+++ b/phprojekt/application/Default/Controllers/JsController.php
@@ -98,14 +98,8 @@ class JsController extends IndexController
                     phpr.DefaultModule    = "Project";
                     phpr.viewManager      = new phpr.Default.System.ViewManager();
                     phpr.pageManager      = new phpr.Default.System.PageManager();
-                    var availableModules = [';
-        $module = new Phprojekt_Module_Module();
-        foreach ($module->fetchAll() as $m) {
-            $scripttext .= "'{$m->name}', ";
-        }
-        $scripttext .= '];
                     phpr.module           = phpr.pageManager.getConfigFromWindow().moduleName;
-                    if (dojo.indexOf(availableModules, phpr.module) == -1) {
+                    if (phpr.pageManager.getModule(phpr.module) === null) {
                         phpr.module       = "Project";
                     }
                     phpr.submodule        = null;


### PR DESCRIPTION
If the user has an unknown module as url hash or cookie, the last thing the
initialization routine would do is to publish ${MODULE}.load(), which is unheard
if ${MODULE} doesn't exist.
This problem occurs after upgrading. If a user was at a module which is removed,
the only way to get out is to clear all cookies, which is extremely annoying.

This fix just inserts a list of all known modules and sets the module to
"Project" if the saved module is unknown.
