### PR TITLE
#219 - fix datepicker defaulting to 1970

### DIFF
--- a/phprojekt/application/Default/Views/dojo/scripts/system/phpr.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/system/phpr.js
@@ -508,7 +508,9 @@ dojo.declare("phpr.DateTextBox", [dijit.form.DateTextBox], {
         // Summary:
         //    Parses as string as a Date, according to constraints
         // Date
-        return this.dateLocaleModule.parse(value, constraints) || (this._isEmpty(value) ? '' : undefined);
+
+        var date = this.dateLocaleModule.parse(value, constraints);
+        return date || undefined;
     },
 
     serialize: function(d, options) {


### PR DESCRIPTION
The datepicker returned "" if the entered value was empty.
"" later gets parsed to 1970 from within dojo which leads to the bug.
