### PR TITLE
Added Project_Models_Project::fetchSubprojects.

### DIFF
--- a/phprojekt/application/Project/Models/Project.php
+++ b/phprojekt/application/Project/Models/Project.php
@@ -334,4 +334,14 @@ class Project_Models_Project extends Phprojekt_Item_Abstract
             );
         }
     }
+
+    /**
+     * Fetches all subprojects of this project.
+     *
+     * @return array of Project_Models_Project The subprojects
+     */
+    public function fetchSubprojects()
+    {
+        return $this->fetchAll(Phprojekt::getInstance()->getDb()->quoteInto('project_id = ?', $this->id));
+    }
 }


### PR DESCRIPTION
Without this, subprojects needed to be fetched via
fetchAll('project_id = ?') which requires knowledge of the database.

This makes it easier to fetch them and provides a nice api that doesn't
need knowledge about the database.
