### PR TITLE
Don't break on modules without Views

### DIFF
--- a/phprojekt/application/Default/Controllers/JsController.php
+++ b/phprojekt/application/Default/Controllers/JsController.php
@@ -339,7 +339,8 @@ class JsController extends IndexController
         $output = "";
         $files = scandir($path);
         foreach ($files as $file) {
-            if ($file != '.'  && $file != '..' && $file != 'Default') {
+            if ($file != '.'  && $file != '..' && $file != 'Default'
+                    && is_dir($path . '/' . $file . '/Views')) {
                 if (is_dir($path . $file . '/Views/dojo/scripts/')) {
                     $scripts = scandir($path . $file . '/Views/dojo/scripts/');
                 } else {


### PR DESCRIPTION
The client tries to instantiate phpr.{module name}.Main for all modules.
This breaks if the module contains no view at all (for example the upcoming
webdav module).

If the module doesn't have a Views folder, the client doesn't even need to
know about it.
