### PR TITLE
Added Project_Models_Project::getTree

### DIFF
--- a/phprojekt/application/Project/Models/Project.php
+++ b/phprojekt/application/Project/Models/Project.php
@@ -334,4 +334,16 @@ class Project_Models_Project extends Phprojekt_Item_Abstract
             );
         }
     }
+
+    /**
+     * Returns the tree node for this project.
+     *
+     * The node allows navigating to subprojects and other operations on the project tree.
+     *
+     * @return Phprojekt_Tree_Node_Database A Tree node belonging to this project.
+     */
+    public function getTree()
+    {
+        return new Phprojekt_Tree_Node_Database($this);
+    }
 }

--- a/phprojekt/application/Project/Models/Project.php
+++ b/phprojekt/application/Project/Models/Project.php
@@ -344,6 +344,8 @@ class Project_Models_Project extends Phprojekt_Item_Abstract
      */
     public function getTree()
     {
-        return new Phprojekt_Tree_Node_Database($this);
+        $tree = new Phprojekt_Tree_Node_Database($this);
+        $tree->setup();
+        return $tree;
     }
 }


### PR DESCRIPTION
This is a shortcut to get the tree node for a given project and provides a hint
in the Project model definition that this is the way to navigate the project tree.

(As discussed)
