### PR TITLE
Correctly log errors and redirect/fail during startup

### DIFF
--- a/phprojekt/library/Phprojekt.php
+++ b/phprojekt/library/Phprojekt.php
@@ -239,7 +239,7 @@ class Phprojekt
                 $this->_db = Zend_Db::factory($this->_config->database);
             } catch (Zend_Db_Adapter_Exception $error) {
                 error_log($error->getMessage());
-                die();
+                $this->_dieWithInternalServerError();
             }
         }
 
@@ -260,7 +260,7 @@ class Phprojekt
                 $this->_log = new Phprojekt_Log($this->_config);
             } catch (Zend_Log_Exception $error) {
                 error_log($error->getMessage());
-                die();
+                $this->_dieWithInternalServerError();
             }
         }
 
@@ -435,7 +435,7 @@ class Phprojekt
             $this->_config = new Zend_Config_Ini(PHPR_CONFIG_FILE, PHPR_CONFIG_SECTION, true);
         } catch (Zend_Config_Exception $error) {
             error_log('There is an error in your configuration.php: ' . $error->getMessage());
-            die();
+            $this->_dieWithInternalServerError();
         }
 
         // Set webpath, tmpPath and applicationPath
@@ -476,7 +476,7 @@ class Phprojekt
             $this->_cache = Zend_Cache::factory('Core', 'File', $frontendOptions, $backendOptions);
         } catch (Exception $error) {
             error_log("The directory " . PHPR_TEMP_PATH . "zendCache do not exists or not have write access.");
-            die();
+            $this->_dieWithInternalServerError();
 
         }
         Zend_Db_Table_Abstract::setDefaultMetadataCache($this->_cache);
@@ -516,7 +516,7 @@ class Phprojekt
             $message = "Your PHP does not meet the requirements needed for P6.<br />"
                 . implode("<br />", $missingRequirements);
             error_log($message);
-            die();
+            $this->_dieWithInternalServerError();
         }
 
         $helperPaths = $this->_getHelperPaths();
@@ -966,6 +966,15 @@ class Phprojekt
 
         return array('requirements'    => $requirements,
                      'recommendations' => $recommendations);
+    }
+
+    private function _dieWithInternalServerError()
+    {
+        $response = new Zend_Controller_Response_Http();
+        $response->setHttpResponseCode(500);
+        $response->setBody('Internal Server Error. Please contact an administrator.');
+        $response->sendResponse();
+        die();
     }
 
     private function _redirectToSetupAndDie()

--- a/phprojekt/library/Phprojekt.php
+++ b/phprojekt/library/Phprojekt.php
@@ -238,7 +238,7 @@ class Phprojekt
             try {
                 $this->_db = Zend_Db::factory($this->_config->database);
             } catch (Zend_Db_Adapter_Exception $error) {
-                echo $error->getMessage();
+                error_log($error->getMessage());
                 die();
             }
         }
@@ -259,7 +259,8 @@ class Phprojekt
             try {
                 $this->_log = new Phprojekt_Log($this->_config);
             } catch (Zend_Log_Exception $error) {
-                die($error->getMessage());
+                error_log($error->getMessage());
+                die();
             }
         }
 
@@ -431,8 +432,11 @@ class Phprojekt
             $response = new Zend_Controller_Request_Http();
             $webPath  = $response->getScheme() . '://' . $response->getHttpHost() . $response->getBasePath() . '/';
             header("Location: " . $webPath . "setup.php");
-            die('You need the file configuration.php to continue. Have you tried the <a href="' . $webPath
-                . 'setup.php">setup</a> routine?'."\n".'<br />Original error: ' . $error->getMessage());
+            error_log(
+                'You need the file configuration.php to continue. Have you tried the <a href="' . $webPath
+                . 'setup.php">setup</a> routine?'."\n".'<br />Original error: ' . $error->getMessage()
+            );
+            die();
         }
 
         // Set webpath, tmpPath and applicationPath
@@ -472,7 +476,9 @@ class Phprojekt
         try {
             $this->_cache = Zend_Cache::factory('Core', 'File', $frontendOptions, $backendOptions);
         } catch (Exception $error) {
-            die("The directory " . PHPR_TEMP_PATH . "zendCache do not exists or not have write access.");
+            error_log("The directory " . PHPR_TEMP_PATH . "zendCache do not exists or not have write access.");
+            die();
+
         }
         Zend_Db_Table_Abstract::setDefaultMetadataCache($this->_cache);
 
@@ -510,7 +516,8 @@ class Phprojekt
         if (!empty($missingRequirements)) {
             $message = "Your PHP does not meet the requirements needed for P6.<br />"
                 . implode("<br />", $missingRequirements);
-            die($message);
+            error_log($message);
+            die();
         }
 
         $helperPaths = $this->_getHelperPaths();


### PR DESCRIPTION
We can't use our own error log, because we need the configuration to find it's
location. die() just prints to standard output which finally gets sent to the
client.

This might send things to the client that it should not see, and it prevents
administrators from examining the error after it happened.

By using error_log($message); die(); we print it to the webserver's error log,
which doesn't have these problems.

Additionally, we should send a 500 if something is wrong and use Zend for the redirect and the 500.
