### PR TITLE
PHProjekt #200

### DIFF
--- a/phprojekt/application/Default/Helpers/Right.php
+++ b/phprojekt/application/Default/Helpers/Right.php
@@ -302,13 +302,6 @@ final class Default_Helpers_Right
                     $resultRights[$node['id']] = $rights[$node['id']];
                 }
             }
-
-            if (isset($params['dataAccess'])) {
-                if (!Phprojekt_Module::saveTypeIsGlobal($moduleId)) {
-                    // Items under a project => add admin with full access
-                    $resultRights[1] = Phprojekt_Acl::ALL;
-                }
-            }
         } else {
             $resultRights = $rights;
         }

--- a/phprojekt/application/Default/Helpers/Save.php
+++ b/phprojekt/application/Default/Helpers/Save.php
@@ -90,7 +90,7 @@ final class Default_Helpers_Save
             throw new Phprojekt_PublishedException($error['label'] . ': ' . $error['message']);
         } else if (!self::_checkModule(1, $projectId)) {
             throw new Phprojekt_PublishedException('You do not have access to add projects on the parent project');
-        } else if (!self::_checkItemRights($node->getActiveRecord(), 'Project')) {
+        } else if (!self::_checkItemRights($node->getActiveRecord(), 'Project') && !Phprojekt_Auth::isAdminUser()) {
             throw new Phprojekt_PublishedException('You do not have access to do this action');
         } else {
             if (null === $node->id || $node->id == 0) {
@@ -103,7 +103,7 @@ final class Default_Helpers_Save
             // Save access, modules and roles only if the user have "admin" right
             $itemRights = Phprojekt_Loader::getLibraryClass('Phprojekt_Item_Rights');
             $check      = $itemRights->getRights(1, $node->getActiveRecord()->id);
-            if ($check['currentUser']['admin']) {
+            if ($check['currentUser']['admin'] || Phprojekt_Auth::isAdminUser()) {
                 $rights = Default_Helpers_Right::getItemRights($params, 1, $newItem);
 
                 if (count($rights) > 0) {
@@ -185,7 +185,7 @@ final class Default_Helpers_Save
             throw new Phprojekt_PublishedException($error['label'] . ': ' . $error['message']);
         } else if (!self::_checkModule($moduleId, $projectId)) {
             throw new Phprojekt_PublishedException('The parent project do not have enabled this module');
-        } else if (!self::_checkItemRights($model, $moduleName)) {
+        } else if (!self::_checkItemRights($model, $moduleName) && !Phprojekt_Auth::isAdminUser()) {
             throw new Phprojekt_PublishedException('You do not have access to do this action');
         } else {
             // Set the projectId to 1 for global modules
@@ -200,7 +200,7 @@ final class Default_Helpers_Save
             // Save access only if the user have "admin" right
             $itemRights = Phprojekt_Loader::getLibraryClass('Phprojekt_Item_Rights');
             $check      = $itemRights->getRights($moduleId, $model->id);
-            if ($check['currentUser']['admin']) {
+            if ($check['currentUser']['admin'] || Phprojekt_Auth::isAdminUser()) {
                 if ($moduleName == 'Core') {
                     $rights = Default_Helpers_Right::getModuleRights($params);
                 } else {

--- a/phprojekt/application/Default/Views/dojo/scripts/system/PageManager.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/system/PageManager.js
@@ -201,7 +201,7 @@ dojo.declare("phpr.Default.System.PageManager", null, {
         // Summary:
         //      returns a module by its name or null if it is not registered
         var mod = this._modules[name];
-        if (mod) {
+        if (mod !== undefined && mod) {
             return mod;
         } else {
             return null;
@@ -275,7 +275,6 @@ dojo.declare("phpr.Default.System.PageManager", null, {
         //      TODO: this control flow is bogus, there is no reason why the initial page loading should be done by the
         //      load function of the Main class (it will not work to call it twice and it has nothing to do with the
         //      Main class in general)
-
         if (this.getModule(module) !== null) {
             module.load();
         } else {

--- a/phprojekt/library/Phprojekt/Item/Abstract.php
+++ b/phprojekt/library/Phprojekt/Item/Abstract.php
@@ -322,19 +322,21 @@ abstract class Phprojekt_Item_Abstract extends Phprojekt_ActiveRecord_Abstract i
      */
     public function fetchAll($where = null, $order = null, $count = null, $offset = null, $select = null, $join = null)
     {
-        // Only fetch records with read access
-        $join .= sprintf(' INNER JOIN item_rights ON (item_rights.item_id = %s
-            AND item_rights.module_id = %d AND item_rights.user_id = %d) ',
-            $this->getAdapter()->quoteIdentifier($this->getTableName() . '.id'),
-            Phprojekt_Module::getId($this->getModelName()), Phprojekt_Auth_Proxy::getEffectiveUserId());
+        if (!Phprojekt_Auth::isAdminUser()) {
+            // Only fetch records with read access
+            $join .= sprintf(' INNER JOIN item_rights ON (item_rights.item_id = %s
+                AND item_rights.module_id = %d AND item_rights.user_id = %d) ',
+                $this->getAdapter()->quoteIdentifier($this->getTableName() . '.id'),
+                Phprojekt_Module::getId($this->getModelName()), Phprojekt_Auth_Proxy::getEffectiveUserId());
 
-        // Set where
-        if (null !== $where) {
-            $where .= ' AND ';
+            // Set where
+            if (null !== $where) {
+                $where .= ' AND ';
+            }
+            $where .= ' (' . sprintf('(%s.owner_id = %d OR %s.owner_id IS NULL)', $this->getTableName(),
+                Phprojekt_Auth_Proxy::getEffectiveUserId(), $this->getTableName());
+            $where .= ' OR (item_rights.access > 0)) ';
         }
-        $where .= ' (' . sprintf('(%s.owner_id = %d OR %s.owner_id IS NULL)', $this->getTableName(),
-            Phprojekt_Auth_Proxy::getEffectiveUserId(), $this->getTableName());
-        $where .= ' OR (item_rights.access > 0)) ';
 
         return parent::fetchAll($where, $order, $count, $offset, $select, $join);
     }

--- a/phprojekt/library/Phprojekt/Item/Rights.php
+++ b/phprojekt/library/Phprojekt/Item/Rights.php
@@ -239,26 +239,14 @@ class Phprojekt_Item_Rights extends Zend_Db_Table_Abstract
             $values        = array();
             $currentUserId = (int) Phprojekt_Auth_Proxy::getEffectiveUserId();
 
-            // Set the current User
-            // Use for an empty rights, if not, will be re-write
-            $values['currentUser']['moduleId'] = (int) $moduleId;
-            $values['currentUser']['itemId']   = (int) $itemId;
-            $values['currentUser']['userId']   = $currentUserId;
-            $access                            = Phprojekt_Acl::convertBitmaskToArray((int) Phprojekt_Acl::ALL);
-            $values['currentUser']             = array_merge($values['currentUser'], $access);
-
             $where = sprintf('module_id = %d AND item_id = %d', (int) $moduleId, (int) $itemId);
             $rows  = $this->fetchAll($where)->toArray();
             foreach ($rows as $row) {
                 $access  = Phprojekt_Acl::convertBitmaskToArray($row['access']);
-                if ($currentUserId == $row['user_id']) {
-                    $values['currentUser'] = array_merge($values['currentUser'], $access);
-                } else {
-                    $values[$row['user_id']]['moduleId'] = (int) $moduleId;
-                    $values[$row['user_id']]['itemId']   = (int) $itemId;
-                    $values[$row['user_id']]['userId']   = (int) $row['user_id'];
-                    $values[$row['user_id']]             = array_merge($values[$row['user_id']], $access);
-                }
+                $values[$row['user_id']]['moduleId'] = (int) $moduleId;
+                $values[$row['user_id']]['itemId']   = (int) $itemId;
+                $values[$row['user_id']]['userId']   = (int) $row['user_id'];
+                $values[$row['user_id']]             = array_merge($values[$row['user_id']], $access);
             }
             $rightNamespace->right = $values;
         }

--- a/phprojekt/library/Phprojekt/Item/Rights.php
+++ b/phprojekt/library/Phprojekt/Item/Rights.php
@@ -173,9 +173,9 @@ class Phprojekt_Item_Rights extends Zend_Db_Table_Abstract
         $currentUserId = (int) Phprojekt_Auth_Proxy::getEffectiveUserId();
 
         $access = $this->getItemRight($moduleId, $itemId, $currentUserId);
-        if ($access == 0) {
+        if (null === $access) {
             // Use for an empty rights
-            $access = (int) Phprojekt_Acl::ALL;
+            $access = (int) Phprojekt_Acl::NONE;
         }
         $values['currentUser']['moduleId'] = (int) $moduleId;
         $values['currentUser']['itemId']   = (int) $itemId;

--- a/phprojekt/library/Phprojekt/Tree/Node/Database.php
+++ b/phprojekt/library/Phprojekt/Tree/Node/Database.php
@@ -246,6 +246,10 @@ class Phprojekt_Tree_Node_Database implements IteratorAggregate
         $sessionName     = 'Phprojekt_Tree_Node_Database-applyRights';
         $rightsNamespace = new Zend_Session_Namespace($sessionName);
 
+        if (Phprojekt_Auth::isAdminUser()) {
+            return $object;
+        }
+
         // Get the itemRights relation
         if (isset($rightsNamespace->rights)) {
             $rights = $rightsNamespace->rights;


### PR DESCRIPTION
http://jira.opensource.mayflower.de/jira/browse/PHPROJEKT-200.

PHProjekt never checked for admin rights but rather always added full rights for the admin user with user id  = 1 to the database. I removed that. As the admin user is able to see an item he will also appear as the currentUser. The rights of the current user are also saved. To avoid this backdoor, leading to rights for the admin beeing added to the db again (without explicitly adding it as a user) I removed the currentUser from getUserRights. Further refactoring of the current user behavior needs to be done to solve the overall issue, but so far the provided solution works.
