### PR TITLE
Send notifications only once

### DIFF
--- a/phprojekt/application/Calendar2/Controllers/IndexController.php
+++ b/phprojekt/application/Calendar2/Controllers/IndexController.php
@@ -283,7 +283,7 @@ class Calendar2_IndexController extends IndexController
         }
 
         if ($sendNotifications) {
-            $model->notify();
+            $model->getNotification()->send(Phprojekt_Notification::TRANSPORT_MAIL_TEXT);
         }
 
         Phprojekt_Converter_Json::echoConvert(
@@ -497,10 +497,16 @@ class Calendar2_IndexController extends IndexController
             $model      = $model->findOccurrence($id, $occurrence);
         }
 
-        if ($multiple) {
-            $model->delete($sendNotifications);
+        if ($multiple || empty($model->rrule)) {
+            if ($sendNotifications) {
+                $notification = $model->getNotification();
+                $notification->setControllProcess(Phprojekt_Notification::LAST_ACTION_DELETE);
+                $notification->send();
+            }
+            $model->delete();
         } else {
-            $model->deleteSingleEvent($sendNotifications);
+            $model->deleteSingleEvent();
+            $model->getNotification()->send();
         }
 
         Phprojekt_Converter_Json::echoConvert(


### PR DESCRIPTION
Instead of having a notify method in Calendar2_Models_Calendar2, overwrite
getNotification to return our custom notification class. This matches default
PHProjekt behaviour.
