### PR TITLE
fix not working id field

### DIFF
--- a/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/Dnd.js
+++ b/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/Dnd.js
@@ -340,13 +340,8 @@ phpr.editModuleDesignerField = function(nodeId) {
             break;
     }
 
-    fieldsTable.push(dojo.create('input', {
-            type: "hidden",
-            name: "id",
-            class: "hiddenValue",
-            dojoType: "dijit.form.TextBox",
-            value: "id"
-        })
+    fieldsTable.push(
+        template.hiddenFieldRender('', 'id', id)
     );
 
     fieldsTable.push(


### PR DESCRIPTION
the id field did not work, we now use the default method (templateRenderer)
which works.
the missing id caused the moduledesigner to delete the old table column and
create a new one, which led to data loss.
