### PR TITLE
Use $this->getInformation() instead of $this->_dbManager in Item_Abstract

### DIFF
--- a/phprojekt/library/Phprojekt/Item/Abstract.php
+++ b/phprojekt/library/Phprojekt/Item/Abstract.php
@@ -184,7 +184,7 @@ abstract class Phprojekt_Item_Abstract extends Phprojekt_ActiveRecord_Abstract i
     public function recordValidate()
     {
         $data   = $this->_data;
-        $fields = $this->_dbManager->getFieldDefinition(Phprojekt_ModelInformation_Default::ORDERING_FORM);
+        $fields = $this->getInformation()->getFieldDefinition(Phprojekt_ModelInformation_Default::ORDERING_FORM);
 
         return $this->_validate->recordValidate($this, $data, $fields);
     }


### PR DESCRIPTION
This allows subclasses to overwrite getInformation with a custom, static
ModelInformation like it was originally meant to work.
