### PR TITLE
fix missing focuesed slider icon.

### DIFF
--- a/phprojekt/htdocs/css/themes/phprojekt/form/Slider.css
+++ b/phprojekt/htdocs/css/themes/phprojekt/form/Slider.css
@@ -47,9 +47,11 @@
     border: 0px;
     width: 15px;
     height: 18px;
+    background-position: 0 0 !important;
     background: url("../images/preciseSliderThumb.png") no-repeat center top;
     cursor: pointer;
 }
+
 .phprojekt .dijitSliderFocused .dijitSliderImageHandleH {
     background-image: url("../images/preciseSliderThumbFocus.png");
 }


### PR DESCRIPTION
since we use the claro theme as a fallback styling, the more specific claro
rules overlapped with our and made the icon disappear.
