### PR TITLE
PHProjetk-167: Fix escaping

### DIFF
--- a/phprojekt/htdocs/Setup/Controllers/IndexController.php
+++ b/phprojekt/htdocs/Setup/Controllers/IndexController.php
@@ -69,7 +69,7 @@ class IndexController extends Zend_Controller_Action
 
         $this->view->webPath = $webPath;
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = "";
         $this->view->error   = array();
 
         $this->view->exportModules = Setup_Models_Migration::getModulesToMigrate();
@@ -117,7 +117,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonDatabaseFormAction()
     {
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = "";
         $this->view->dbHost  = self::DEFAULT_DBHOST;
         $this->view->dbUser  = self::DEFAULT_DBUSER;
         $this->view->dbPass  = '';
@@ -156,7 +156,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonDatabaseSetupAction()
     {
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = '';
 
         $params = array(
             'serverType' => Cleaner::sanitize('string', $this->getRequest()->getParam('serverType')),
@@ -202,7 +202,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonUsersFormAction()
     {
         $this->view->message          = array();
-        $this->view->success          = array();
+        $this->view->success          = '';
         $this->view->adminPass        = '';
         $this->view->adminPassConfirm = '';
         $this->view->testPass         = '';
@@ -240,7 +240,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonUsersSetupAction()
     {
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = '';
 
         $params = array(
             'adminPass'        => Cleaner::sanitize('string', $this->getRequest()->getParam('adminPass')),
@@ -285,7 +285,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonFoldersFormAction()
     {
         $this->view->message    = array();
-        $this->view->success    = array();
+        $this->view->success    = '';
         $this->view->privateDir = $this->_setup->getProposedPrivateFolderPath();
 
         $message  = null;
@@ -317,7 +317,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonFoldersSetupAction()
     {
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = '';
 
         $params = array(
             'privateDir'        => (string) $this->getRequest()->getParam('privateDir'),
@@ -381,7 +381,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonTablesFormAction()
     {
         $this->view->message      = array();
-        $this->view->success      = array();
+        $this->view->success      = '';
         $this->view->useExtraData = self::DEFAULT_USE_EXTRA_DATA;
 
         $message  = null;
@@ -413,7 +413,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonTablesSetupAction()
     {
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = '';
 
         $params = array('useExtraData' => (int) $this->getRequest()->getParam('useExtraData'));
 
@@ -449,7 +449,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonMigrationFormAction()
     {
         $this->view->message             = array();
-        $this->view->success             = array();
+        $this->view->success             = '';
         $this->view->migrationConfigFile = '';
         $this->view->diffToUtc           = self::DEFAULT_DIFF_TO_UTC;
 
@@ -484,7 +484,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonMigrateSetupAction()
     {
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = '';
 
         $params = array(
             'migrationConfigFile' => Cleaner::sanitize('string', $this->getRequest()->getParam('migrationConfigFile')),
@@ -541,7 +541,7 @@ class IndexController extends Zend_Controller_Action
     public function jsonFinishAction()
     {
         $this->view->message = array();
-        $this->view->success = array();
+        $this->view->success = "";
 
         if (null !== $this->_setup) {
             ob_start();

--- a/phprojekt/htdocs/Setup/Models/Config.php
+++ b/phprojekt/htdocs/Setup/Models/Config.php
@@ -262,18 +262,18 @@ class Setup_Models_Config
         $content .= $this->_eol;
 
         $content .= '; For this Developer Release, it just has been tested with pdo_mysql.' . $this->_eol;
-        $content .= 'database.adapter = "' . $adapter . '"' . $this->_eol;
+        $content .= 'database.adapter = "' . addcslashes($adapter, '"') . '"' . $this->_eol;
         $content .= $this->_eol;
         $content .= '; The assigned name or IP address for the database server.' . $this->_eol;
-        $content .= 'database.params.host = "' . $host . '"' . $this->_eol;
+        $content .= 'database.params.host = "' . addcslashes($host, '"') . '"' . $this->_eol;
         $content .= $this->_eol;
         $content .= '; Username and password with the appropriate rights for Phprojekt to access to' . $this->_eol;
         $content .= '; the database.' . $this->_eol;
-        $content .= 'database.params.username = "' . $username . '"' . $this->_eol;
-        $content .= 'database.params.password = "' . $password . '"' . $this->_eol;
+        $content .= 'database.params.username = "' . addcslashes($username, '"') . '"' . $this->_eol;
+        $content .= 'database.params.password = "' . addcslashes($password, '"') . '"' . $this->_eol;
         $content .= $this->_eol;
         $content .= '; Name of the database, inside the server' . $this->_eol;
-        $content .= 'database.params.dbname = "' . $dbname . '"' . $this->_eol;
+        $content .= 'database.params.dbname = "' . addcslashes($dbname, '"') . '"' . $this->_eol;
 
         return $content;
     }
@@ -368,18 +368,18 @@ class Setup_Models_Config
         $content .= $this->_eol;
         $content .= '; If mailTransport is set to 0, then fill all the needed \'smtp*\' values:' . $this->_eol;
         $content .= '; Name or IP address of the SMTP server to be used to send that notifications.' . $this->_eol;
-        $content .= 'smtpServer = "' . $server . '"' . $this->_eol;
+        $content .= 'smtpServer = "' . addcslashes($server, '"') . '"' . $this->_eol;
         $content .= '; If the SMTP server requires authentication, remove the semicolons \';\' in the' . $this->_eol;
         $content .= '; three following lines and write inside the inverted commas "" the appropriate' . $this->_eol;
         $content .= '; username and password. Auth mode: leave this as "login" if you don\'t know.' . $this->_eol;
         $content .= '; Other available options: plain, cram-md5' . $this->_eol;
         $content .= ';smtpAuth     = "login"' . $this->_eol;
         if (empty($user) && empty($password)) {
-            $content .= ';smtpUser     = "' . $user . '"' . $this->_eol;
-            $content .= ';smtpPassword = "' . $password . '"' . $this->_eol;
+            $content .= ';smtpUser     = "' . addcslashes($user, '"') . '"' . $this->_eol;
+            $content .= ';smtpPassword = "' . addcslashes($password, '"') . '"' . $this->_eol;
         } else {
-            $content .= 'smtpUser     = "' . $user . '"' . $this->_eol;
-            $content .= 'smtpPassword = "' . $password . '"' . $this->_eol;
+            $content .= 'smtpUser     = "' . addcslashes($user, '"') . '"' . $this->_eol;
+            $content .= 'smtpPassword = "' . addcslashes($password, '"') . '"' . $this->_eol;
         }
         $content .= '; You may specify SSL and Port, if the SMTP server of your choice requires them.' . $this->_eol;
         $content .= ';smtpSsl      = ""' . $this->_eol;


### PR DESCRIPTION
We have to escape the parameters that we write to the config, otherwise someone can just use " and close our string
