### PR TITLE
fix bug in module designer with special tab names

### DIFF
--- a/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/Dnd.js
+++ b/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/Dnd.js
@@ -30,6 +30,7 @@ dojo.declare("phpr.Module.Designer", dojo.dnd.AutoSource, {
     //    Extend the dojo Source
     // Description:
     //    Extend the dojo Source
+    tabId: "",
     onDrop:function(source, nodes, copy) {
         if (this != source) {
             this.onDropExternal(source, nodes, copy);
@@ -55,7 +56,9 @@ dojo.declare("phpr.Module.Designer", dojo.dnd.AutoSource, {
 
     markupFactory:function(params, node) {
         params._skipStartup = true;
-        return new phpr.Module.Designer(node, params);
+        var el = new phpr.Module.Designer(node, params);
+        moduleDesignerElements[params.tabId] = el;
+        return el;
     }
 });
 
@@ -96,7 +99,7 @@ phpr.makeModuleDesignerSource = function() {
 
     element.innerHTML = html;
     dojo.parser.parse(element.id);
-    moduleDesignerSource.sync();
+    moduleDesignerElements['moduleDesignerSource'].sync();
 };
 
 phpr.makeModuleDesignerTarget = function(jsonData, tabs) {
@@ -107,7 +110,7 @@ phpr.makeModuleDesignerTarget = function(jsonData, tabs) {
     if (jsonData) {
         var data = dojo.fromJson(jsonData);
         for (var j in tabs) {
-            var tab     = eval("moduleDesignerTarget" + tabs[j]['nameId']);
+            var tab = moduleDesignerElements['moduleDesignerTarget' + tabs[j]['nameId']];
             var element = dojo.byId('moduleDesignerTarget' + tabs[j]['nameId']);
             var html    = '<div style="text-align: center; padding-bottom: 2px;">'
                 + phpr.nls.get('Active fields in the module')
@@ -150,9 +153,9 @@ phpr.deleteModuleDesignerField = function(nodeId) {
     // Delete only the target items
     if (tabId != 'moduleDesignerSource') {
         if (node) {
-            var tab = eval(tabId);
+            var tab = moduleDesignerElements[tabId];
             // make sure it is not the anchor
-            if (tab.anchor == node){
+            if (tab.anchor == node) {
                 tab.anchor = null;
             }
             // remove it from the master map

--- a/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/Form.js
+++ b/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/Form.js
@@ -26,6 +26,30 @@ dojo.require("dijit.Dialog");
 dojo.declare("phpr.Module.Form", phpr.Core.DialogForm, {
     _dialog: null,
 
+    constructor: function() {
+        // FIXME: this solution for storing the moduleDesigner elements leaks memory and is very hard to garbage collect because
+        // it introduces global variables. It should be refactored to work more object oriented.
+        window.moduleDesignerElements = {};
+    },
+
+    destroy: function() {
+        if (moduleDesignerElements) {
+            var collector = new phpr.Default.System.GarbageCollector();
+            for (var i in moduleDesignerElements) {
+                if (moduleDesignerElements.hasOwnProperty(i)) {
+                    collector.addNode(moduleDesignerElements[i]);
+                }
+            }
+            collector.collect();
+
+            delete moduleDesignerElements;
+
+            collector.destroy();
+        }
+
+        this.inherited(arguments);
+    },
+
     initData:function() {
         // Get all the active users
         this._moduleDesignerUrl  = phpr.webpath + 'index.php/Core/moduleDesigner/jsonDetail/nodeId/1/id/' + this.id;
@@ -151,7 +175,7 @@ dojo.declare("phpr.Module.Form", phpr.Core.DialogForm, {
         var formPosition = 0;
         var self         = this;
         for (var j in tabs) {
-            var tab = eval("moduleDesignerTarget" + tabs[j]['nameId']);
+            var tab = moduleDesignerElements["moduleDesignerTarget" + tabs[j]['nameId']];
             tab.getAllNodes().forEach(function(node) {
                 var t = tab._normalizedCreator(node);
                 i++;

--- a/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/template/moduleDesigner.html
+++ b/phprojekt/application/Core/Views/dojo/scripts/Administration/Module/template/moduleDesigner.html
@@ -1,6 +1,6 @@
 <div class="claro" id="moduleDesignerContent" style="width: 100%; height: 100%; background-color: #294064;">
     <div style="background-color: #294064; height: 98%; width: 48%; float: left;">
-        <div dojoType="phpr.Module.Designer" id="moduleDesignerSource" jsId="moduleDesignerSource" copyOnly="false"
+        <div dojoType="phpr.Module.Designer" id="moduleDesignerSource" tabId="moduleDesignerSource" copyOnly="false"
         skipForm="true" selfAccept="false"
         style="background-color: #fff; height: 65%; width: 100%; margin: 4px; overflow: auto;">
         </div>
@@ -40,7 +40,7 @@
             {% for tab in tabs %}
             <div dojoType="dijit.layout.ContentPane" title="{{tab.name}}">
                 <div dojoType="phpr.Module.Designer" id="moduleDesignerTarget{{tab.nameId}}"
-                jsId="moduleDesignerTarget{{tab.nameId}}" skipForm="true" selfAccept="true"
+                tabId="moduleDesignerTarget{{tab.nameId}}" skipForm="true" selfAccept="true"
                 style="background-color: #fff; width: 100%; height: 95%; margin: 0px;">
                 </div>
             </div>


### PR DESCRIPTION
the moduledesigner used eval to fetch the tabs it created.
this leaded to errors when the tab names contained for examples arithmetic
operators like "-".
We now use a global hashMap to store the tabs, which is a little bit better but should
be refactored at some point in time because it causes memleaks like the old solution.
