### PR TITLE
disallow ? in field names in the database manager

### DIFF
--- a/phprojekt/application/Core/Languages/de.inc.php
+++ b/phprojekt/application/Core/Languages/de.inc.php
@@ -80,6 +80,7 @@ $lang["Please enter a name for this module"] = "Bitte geben Sie einen Namen für
 $lang["The module name must start with a letter"] = "Der Modulname muss mit einem Buchstaben beginnen";
 $lang["All the fields must have a table name"] = "Alle Felder einer Tabelle müssen benannt werden";
 $lang["There are two fields with the same Field Name"] = "Es sind zwei Felder mit identischem Namen";
+$lang["\"?\" is not allowed in the field name"]  = "\"?\" ist nicht erlaubt in Feldnamen";
 $lang["The length of the varchar fields must be between 1 and 255"] = "Die Länge der VARCHAR Felder muss zwischen 1 "
     . "und 255 Zeichen sein";
 $lang["The length of the int fields must be between 1 and 11"] = "Die Länge der INT Felder muss zwischen 1 und 11 "

--- a/phprojekt/application/Core/Languages/en.inc.php
+++ b/phprojekt/application/Core/Languages/en.inc.php
@@ -79,6 +79,7 @@ $lang["Please enter a name for this module"] = "Please enter a name for this mod
 $lang["The module name must start with a letter"] = "The module name must start with a letter";
 $lang["All the fields must have a table name"] = "All the fields must have a table name";
 $lang["There are two fields with the same Field Name"] = "There are two fields with the same Field Name";
+$lang["\"?\" is not allowed in the field name"]  = "\"?\" is not allowed in the field name";
 $lang["The length of the varchar fields must be between 1 and 255"] = "The length of the varchar fields must be "
     . "between 1 and 255";
 $lang["The length of the int fields must be between 1 and 11"] = "The length of the int fields must be between 1 and "

--- a/phprojekt/library/Phprojekt/DatabaseManager.php
+++ b/phprojekt/library/Phprojekt/DatabaseManager.php
@@ -557,6 +557,13 @@ class Phprojekt_DatabaseManager extends Phprojekt_ActiveRecord_Abstract implemen
                         'message' => Phprojekt::getInstance()->translate('There are two fields with the same '
                             . 'Field Name')));
                     break;
+                } else if ($valid && strpos($field['tableField'], '?') != false) {
+                    $valid = false;
+                    $this->_error->addError(array(
+                        'field'   => 'Module Designer',
+                        'label'   => Phprojekt::getInstance()->translate('Module Designer'),
+                        'message' => Phprojekt::getInstance()->translate('"?" is not allowed in the field name')));
+                    break;
                 } else if ($valid) {
                     $foundFields[] = $field['tableField'];
                 }


### PR DESCRIPTION
The ? in field names triggers a Zend/PDO bug in which the ? is interpreted as a
variable to be bound, even though the Zend Select object is correctly escaped.
