### PR TITLE
allow arbitrary filters in the grid

### DIFF
--- a/phprojekt/application/Default/Controllers/IndexController.php
+++ b/phprojekt/application/Default/Controllers/IndexController.php
@@ -361,7 +361,6 @@ class IndexController extends Zend_Controller_Action
                 $filterOperator = Cleaner::sanitize('alpha', $filterOperator, null);
                 $filterField    = Cleaner::sanitize('alpha', $filterField, null);
                 $filterRule     = Cleaner::sanitize('alpha', $filterRule, null);
-                $filterValue    = Cleaner::sanitize('filter', $filterValue, null);
                 if (isset($filterOperator) && isset($filterField) &&  isset($filterRule) && isset($filterValue)) {
                     $filterClass->addFilter($filterField, $filterRule, $filterValue, $filterOperator);
                 }

--- a/phprojekt/application/Default/Views/dojo/scripts/Grid.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/Grid.js
@@ -702,7 +702,6 @@ dojo.declare("phpr.Default.Grid", phpr.Default.System.Component, {
                         break;
                     default:
                         input  = '<input type="text" name="filterValue" dojoType="dijit.form.ValidationTextBox" ' +
-                            'regExp="' + phpr.regExpForFilter.getExp() + '" ' +
                             'invalidMessage="' + phpr.regExpForFilter.getMsg() + '" />';
                         rulesOptions = new Array('like', 'notLike', 'begins', 'ends', 'equal', 'notEqual',
                             'major', 'majorEqual', 'minor', 'minorEqual');


### PR DESCRIPTION
since we changed the filter format to json, i think it is safe to remove the
filterValue cleaner. the filterValue is escaped using zend quoteInto() later
anyways, so this should be safe.

http://jira.opensource.mayflower.de/jira/browse/PHPROJEKT-58
