### PR TITLE
Correctly detect unsupported caldav operations.

### DIFF
--- a/phprojekt/application/Calendar2/CalDAV/CalendarBackend.php
+++ b/phprojekt/application/Calendar2/CalDAV/CalendarBackend.php
@@ -216,7 +216,6 @@ class Calendar2_CalDAV_CalendarBackend extends Sabre_CalDAV_Backend_Abstract
      *
      * @return void
      */
-
     public function updateCalendarObject($calendarId, $objectUri, $calendarData)
     {
         $db    = Phprojekt::getInstance()->getDb();

--- a/phprojekt/application/Calendar2/CalDAV/CalendarBackend.php
+++ b/phprojekt/application/Calendar2/CalDAV/CalendarBackend.php
@@ -216,6 +216,7 @@ class Calendar2_CalDAV_CalendarBackend extends Sabre_CalDAV_Backend_Abstract
      *
      * @return void
      */
+
     public function updateCalendarObject($calendarId, $objectUri, $calendarData)
     {
         $db    = Phprojekt::getInstance()->getDb();
@@ -228,7 +229,7 @@ class Calendar2_CalDAV_CalendarBackend extends Sabre_CalDAV_Backend_Abstract
             throw new Sabre_DAV_Exception_NotImplemented('Cannot alter events with modified occurrences');
         }
         $vevent = Sabre_VObject_Reader::read($calendarData)->vevent;
-        if (count($vevent) > 1) {
+        if ($vevent->count() > 1) {
             throw new Sabre_DAV_Exception_NotImplemented('Cannot update specific occurrences');
         }
         $events[0]->fromVObject($vevent);


### PR DESCRIPTION
An api misunderstanding caused us to miss some kinds of unsupported operations.

This still is a problem, though: Both the iPad (and iPhone I assume) and
thunderbird ignore the 501 that get's sent to them. To the user, everything
looks fine.

http://jira.opensource.mayflower.de/jira/browse/PHPROJEKT-334
