### PR TITLE
fix bug in pagemanager that caused a double reload under certain situati...

### DIFF
--- a/phprojekt/application/Default/Views/dojo/scripts/system/PageManager.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/system/PageManager.js
@@ -165,7 +165,7 @@ dojo.declare("phpr.Default.System.PageManager", null, {
             if ("undefined" != typeof state.id) {
                 // If is an id, open a form
                 if (module && (state.id > 0 || state.id === "0" || state.id === 0)) {
-                    if (module !== this.oldmodule || newProject) {
+                    if (!reloaded && (module !== this.oldmodule || newProject)) {
                         this._reloadModule(module, [ state ]);
                     }
                     if (dojo.isFunction(mod.openForm)) {


### PR DESCRIPTION
...ons

the pagemanager would not handle the forcereload flag correctly.
this led to multiple fast redraws which caused error in the expandopane
animation
