### PR TITLE
fix small bug in calendar

### DIFF
--- a/phprojekt/application/Calendar2/Views/dojo/scripts/Main.js
+++ b/phprojekt/application/Calendar2/Views/dojo/scripts/Main.js
@@ -196,6 +196,7 @@ dojo.declare("phpr.Calendar2.Main", phpr.Default.Main, {
                 this.loadCaldavView();
                 break;
             default:
+                this.loadMonthList();
         }
     },
 


### PR DESCRIPTION
the calendar should always display something, even if the given action is invalid.
we now fall back to the month view
