### PR TITLE
fix bug in the output of getProxyableUsersForUserId

### DIFF
--- a/phprojekt/library/Phprojekt/Auth/ProxyTable.php
+++ b/phprojekt/library/Phprojekt/Auth/ProxyTable.php
@@ -122,11 +122,11 @@ class Phprojekt_Auth_ProxyTable
     public function getProxyableUsersForUserId($userId = null)
     {
         $userIds   = $this->getProxyableUserIdsForUserId($userId);
-        $userClass = new Phprojekt_User_User();
 
         $userList = array();
 
         foreach ($userIds as $userId) {
+            $userClass  = new Phprojekt_User_User();
             $userList[] = $userClass->find($userId);
         }
 


### PR DESCRIPTION
we reused the user class every time which led to the last users being
displayed all the time
