### PR TITLE
Try to use UTF-8 everywhere

### DIFF
--- a/phprojekt/configuration.php-dist
+++ b/phprojekt/configuration.php-dist
@@ -73,6 +73,8 @@ database.params.password = "phprojekt_password"
 ; Name of the database, inside the server
 database.params.dbname = "phprojekt"
 
+database.params.charset = "utf8"
+
 ;;;;;;;
 ; LOG ;
 ;;;;;;;

--- a/phprojekt/htdocs/Setup/Models/Config.php
+++ b/phprojekt/htdocs/Setup/Models/Config.php
@@ -275,6 +275,8 @@ class Setup_Models_Config
         $content .= '; Name of the database, inside the server' . $this->_eol;
         $content .= 'database.params.dbname = "' . addcslashes($dbname, '"') . '"' . $this->_eol;
         $content .= 'database.params.port = ' . (int) $port . $this->_eol;
+        $content .= $this->_eol;
+        $content .= 'database.params.charset = "utf8"' . $this->_eol;
 
         return $content;
     }

--- a/phprojekt/htdocs/Setup/Models/Migration.php
+++ b/phprojekt/htdocs/Setup/Models/Migration.php
@@ -346,7 +346,7 @@ CREATE TABLE `calendar` (
   `visibility` int(1) DEFAULT '0',
   `participant_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-)
+) DEFAULT CHARSET utf8
 HERE
     );
         Phprojekt::getInstance()->getDb()->insert(

--- a/phprojekt/library/Phprojekt/Table.php
+++ b/phprojekt/library/Phprojekt/Table.php
@@ -146,7 +146,7 @@ class Phprojekt_Table
         } else {
             $sqlString = substr($sqlString, 0, -2);
         }
-        $sqlString .= ")";
+        $sqlString .= ") DEFAULT CHARSET=utf8";
 
         try {
             $this->_db->getConnection()->exec($sqlString);


### PR DESCRIPTION
This fixes a bug on some machines where zend retrieved data as latin1 from the database, which then caused
jsonTreeAction to omit some names it couldn't parse, which in turn caused an error while "loading workspace".
