### PR TITLE
fix encoding of the spanish filemanager translation

### DIFF
--- a/phprojekt/application/Filemanager/Languages/es.inc.php
+++ b/phprojekt/application/Filemanager/Languages/es.inc.php
@@ -4,7 +4,7 @@ $lang["Filemanager"] = "Archivo";
 
 // Fields
  // Basic Data
-$lang["Title"] = "Título";
+$lang["Title"] = "TÃ­tulo";
 $lang["Comments"] = "Comentarios";
 $lang["Project"] = "Projecto";
 $lang["Upload"] = "Archivos";


### PR DESCRIPTION
somehow the encoding was wrong, i replaced the "í" and now it works
