### PR TITLE
Don't filter out versions above the current one when parsing db files.

### DIFF
--- a/phprojekt/library/Phprojekt/DbParser.php
+++ b/phprojekt/library/Phprojekt/DbParser.php
@@ -339,7 +339,7 @@ class Phprojekt_DbParser
     }
 
     /**
-     * Delete all the version lower than the current module version.
+     * Delete all the versions lower than the current module version.
      *
      * @param string $module Current module of the data.
      * @param array  $data   Array with all the version and data for parse.

--- a/phprojekt/library/Phprojekt/DbParser.php
+++ b/phprojekt/library/Phprojekt/DbParser.php
@@ -339,8 +339,7 @@ class Phprojekt_DbParser
     }
 
     /**
-     * Delete all the version higher than the current one
-     * and the version lower than the current module version.
+     * Delete all the version lower than the current module version.
      *
      * @param string $module Current module of the data.
      * @param array  $data   Array with all the version and data for parse.
@@ -349,12 +348,10 @@ class Phprojekt_DbParser
      */
     private function _getVersionsForProcess($module, $data)
     {
-        $current       = Phprojekt::getVersion();
         $moduleVersion = $this->_getModuleVersion($module);
 
         foreach (array_keys($data) as $version) {
-            if (Phprojekt::compareVersion($moduleVersion, $version) > 0 ||
-                Phprojekt::compareVersion($current, $version) < 0) {
+            if (Phprojekt::compareVersion($moduleVersion, $version) > 0) {
                 unset($data[$version]);
             }
         }


### PR DESCRIPTION
I can only imagine that the idea behind this was the ability to set the
database state by setting the project version. We have real migrations, so
this can't work.

The filtering made us use 6.x.y-dev or 6.x.y-RC because we are setting the 
version to 6.x.y-dev when developing. Changing it to 6.x.y when releasing is 
an unneccessary risk and was not done.

After this commit, we can just use 6.x.y when we are on 6.x.y-dev.
