### PR TITLE
Add the correct root-project rights for new users.

### DIFF
--- a/phprojekt/library/Phprojekt/Item/Rights.php
+++ b/phprojekt/library/Phprojekt/Item/Rights.php
@@ -216,7 +216,7 @@ class Phprojekt_Item_Rights extends Zend_Db_Table_Abstract
         $data['module_id'] = Phprojekt_Module::getId('Project');
         $data['item_id']   = 1;
         $data['user_id']   = (int) $userId;
-        $data['access']    = (int) Phprojekt_Acl::WRITE | Phprojekt_Acl::CREATE;
+        $data['access']    = (int) Phprojekt_Acl::WRITE | Phprojekt_Acl::CREATE | Phprojekt_Acl::READ;
         $this->insert($data);
     }
 


### PR DESCRIPTION
We did not add READ-rights for new users, which caused the creation of new 
projects to fail because the root project item could not be obtained from
it's tree node.

http://jira.opensource.mayflower.de/jira/browse/PHPROJEKT-399
