### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
 env:
     - P6_TEST_CONFIG=configuration-travis.php
 before_script:
+    - pyrus channel-discover pear.symfony.com
     - pyrus install --force phpunit/DbUnit
     - phpenv rehash
     - mysql -u root -e 'create database `phprojekt-test-memory`'


### PR DESCRIPTION
It was broken because DbUnit required pear.symfony.com. Pyrus asks whether we
want to discover it, and the build terminates after waiting 15 minutes.
