### PR TITLE
Make caldav usernames case insensitive

### DIFF
--- a/phprojekt/application/Calendar2/Controllers/CaldavController.php
+++ b/phprojekt/application/Calendar2/Controllers/CaldavController.php
@@ -55,6 +55,7 @@ class Calendar2_CaldavController extends IndexController
         try {
             if (array_key_exists('PHP_AUTH_USER', $_SERVER)) {
                 Phprojekt_Auth::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']);
+                $_SERVER['PHP_AUTH_USER'] = strtolower(Phprojekt_Auth::getRealUser()->username);
             }
         } catch (Phprojekt_Auth_Exception $e) {
             // We have to delete the stack trace here because we need to avoid logging the user's password.


### PR DESCRIPTION
http://jira.opensource.mayflower.de/jira/browse/PHPROJEKT-449

They were "partially" case insensitive. We rely on two authentications. One
is our standard phprojekt authentication (which gets the httpauth values),
which was case insensitive. But the Sabre ACL takes the username directly
from the http headers and is case sensitive.

To work around this, we set $_SERVER['PHP_AUTH_USER'] to the real username
after successful authentication with phprojekt.
