### PR TITLE
Added empty <calendar2_user_relation/> to test fixture

### DIFF
--- a/phprojekt/tests/UnitTests/common.xml
+++ b/phprojekt/tests/UnitTests/common.xml
@@ -301,4 +301,5 @@
     <frontend_message />
 
     <calendar2 />
+    <calendar2_user_relation />
 </dataset>


### PR DESCRIPTION
Without it, dbunit did not clear the table. This leads to duplicated primary 
keys on calendar2_user_relation.
