### PR TITLE
Highlight today in the date selectors

### DIFF
--- a/phprojekt/htdocs/css/themes/phprojekt/form/DateTextBox.css
+++ b/phprojekt/htdocs/css/themes/phprojekt/form/DateTextBox.css
@@ -1,0 +1,3 @@
+.phprojekt .dijitCalendarCurrentDate .dijitCalendarDateLabel {
+    border-color: #769DC0;
+}

--- a/phprojekt/htdocs/min/min/groupsConfig.php
+++ b/phprojekt/htdocs/min/min/groupsConfig.php
@@ -52,6 +52,7 @@ return array(
         "//css/themes/phprojekt/form/ComboBox.css",
         "//css/themes/phprojekt/form/Common.css",
         "//css/themes/phprojekt/form/Common_rtl.css",
+        "//css/themes/phprojekt/form/DateTextBox.css",
         "//css/themes/phprojekt/form/MultipleFilteringSelectBox.css",
         "//css/themes/phprojekt/form/RadioButton.css",
         "//css/themes/phprojekt/form/Rating.css",


### PR DESCRIPTION
This just sets a border-color, because it doesn't look different on the
selected date.

In order to get a different look than the selected date, we have to be be
more important than
   .claro .dijitCalendarDateTemplate .dijitCalendarDateLabel but less
important than
   .claro .dijitCalendarSelectedDate .dijitCalendarDateLabel and I can't
figure out how to do that.
