### PR TITLE
remove class not found logging

### DIFF
--- a/phprojekt/library/Phprojekt/Loader.php
+++ b/phprojekt/library/Phprojekt/Loader.php
@@ -94,7 +94,6 @@ class Phprojekt_Loader extends Zend_Loader
             @self::loadClass($class, self::$_directories);
             return $class;
         } catch (Zend_Exception $error) {
-            Phprojekt::getInstance()->getLog()->warn($error->getMessage());
             return false;
         }
     }


### PR DESCRIPTION
this is not an error because it is also triggered when we just use class_exists to check
