### PR TITLE
Explicitly call index.php instead of relying on DocumentIndex

### DIFF
--- a/phprojekt/application/Core/Views/scripts/upgrade-idle.phtml
+++ b/phprojekt/application/Core/Views/scripts/upgrade-idle.phtml
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <title>PHProjekt</title>
     <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" type="text/css" href="min/min/?g=phprojekt" />
+    <link rel="stylesheet" type="text/css" href="min/min/index.php?g=phprojekt" />
     <script type="text/javascript" src="dojo/dojo/dojo.js"></script>
     <script type="text/javascript">
         dojo.require('dojo.parser');

--- a/phprojekt/application/Core/Views/scripts/upgrade-locked.phtml
+++ b/phprojekt/application/Core/Views/scripts/upgrade-locked.phtml
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <title>PHProjekt</title>
     <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" type="text/css" href="min/min/?g=phprojekt" />
+    <link rel="stylesheet" type="text/css" href="min/min/index.php?g=phprojekt" />
     <script type="text/javascript" src="dojo/dojo/dojo.js"></script>
     <script type="text/javascript">
         dojo.require('dojo.parser');

--- a/phprojekt/application/Core/Views/scripts/upgrade.phtml
+++ b/phprojekt/application/Core/Views/scripts/upgrade.phtml
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <title>PHProjekt</title>
     <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" type="text/css" href="min/min/?g=phprojekt" />
+    <link rel="stylesheet" type="text/css" href="min/min/index.php?g=phprojekt" />
     <script type="text/javascript" src="dojo/dojo/dojo.js"></script>
     <script type="text/javascript">
         dojo.require('dojo.parser');

--- a/phprojekt/application/Default/Views/dojo/index.phtml
+++ b/phprojekt/application/Default/Views/dojo/index.phtml
@@ -6,7 +6,7 @@
     <title>PHProjekt</title>
     <link rel="favicon" href="img/favicon.ico" />
     <link rel="shortcut icon" href="img/favicon.ico" />
-    <link href="min/min/?g=phprojekt" rel="stylesheet" type="text/css" />
+    <link href="min/min/index.php?g=phprojekt" rel="stylesheet" type="text/css" />
 
     <script type="text/javascript">
         var djConfig = {isDebug: false, parseOnLoad: true, bindEncoding: "utf-8",

--- a/phprojekt/application/Default/Views/dojo/login.phtml
+++ b/phprojekt/application/Default/Views/dojo/login.phtml
@@ -3,7 +3,7 @@
     <title>PHProjekt</title>
     <link rel="favicon" href="<?php echo $this->baseUrl('img/favicon.ico'); ?>" type="image/x-icon" ></link>
     <link rel="shortcut icon" href="<?php echo $this->baseUrl('img/favicon.ico'); ?>" type="image/x-icon" ></link>
-    <link href="<?php echo $this->baseUrl('min/min/?g=login') ?>" rel="stylesheet" type="text/css" />
+    <link href="<?php echo $this->baseUrl('min/min/index.php?g=login') ?>" rel="stylesheet" type="text/css" />
     <script type="text/javascript">
         var djConfig = {isDebug: false, parseOnLoad: true, bindEncoding: "utf-8",
                         locale: 'en', useCommentedJson: true};

--- a/phprojekt/application/Default/Views/dojo/upload.phtml
+++ b/phprojekt/application/Default/Views/dojo/upload.phtml
@@ -6,7 +6,7 @@
     <link rel="favicon" href="<?php echo $this->baseUrl('img/favicon.ico'); ?>"></link>
     <link rel="favicon" href="<?php echo $this->baseUrl('img/favicon.ico'); ?>"></link>
     <link rel="shortcut icon" href="<?php echo $this->baseUrl('img/favicon.ico'); ?>"></link>
-    <link href="<?php echo $this->baseUrl('min/min/?g=phprojekt" rel="stylesheet'); ?>" type="text/css" />
+    <link href="<?php echo $this->baseUrl('min/min/index.php?g=phprojekt" rel="stylesheet'); ?>" type="text/css" />
 
     <script type="text/javascript">
         var djConfig = {isDebug: false, parseOnLoad: true, useCommentedJson: true};

--- a/phprojekt/htdocs/Setup/Views/dojo/index.phtml
+++ b/phprojekt/htdocs/Setup/Views/dojo/index.phtml
@@ -5,7 +5,7 @@
     <title>PHProjekt</title>
     <link rel="favicon" href="img/favicon.ico" type="image/x-icon" ></link>
     <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon" ></link>
-    <link href="min/min/?g=phprojekt" rel="stylesheet" type="text/css" />
+    <link href="min/min/index.php?g=phprojekt" rel="stylesheet" type="text/css" />
 
     <style type="text/css">
         .dj_ie .phprojekt #serverFeedback {


### PR DESCRIPTION
If apache DocumentIndex is not used, the index.php won't be called if
it's not explicitly specified in the link. Therefore we do that as some
installations might not have DocumentIndex set to index.php.
