### PR TITLE
modify grid doubleclick delay to match windows default

### DIFF
--- a/phprojekt/application/Default/Views/dojo/scripts/Grid.js
+++ b/phprojekt/application/Default/Views/dojo/scripts/Grid.js
@@ -48,7 +48,7 @@ dojo.declare("phpr.Default.Grid", phpr.Default.System.Component, {
     splitFields:   [],
     _lastTime:     null,
     _active:       false,
-    _doubleClickMaxTime: 750,
+    _doubleClickMaxTime: 500,
     _gridComboAction: null,
 
     // gridFilters Widget


### PR DESCRIPTION
750ms was too long, windows uses 500ms, so we should use it too
