### PR TITLE
Throw an exception in case the user doesn't have an associated contract

### DIFF
--- a/phprojekt/application/Timecard/Controllers/IndexController.php
+++ b/phprojekt/application/Timecard/Controllers/IndexController.php
@@ -389,11 +389,6 @@ class Timecard_IndexController extends IndexController
         list($start, $end) = $this->_yearMonthParamToStartEndDT();
 
         $contracts = Timecard_Models_Contract::fetchByUserAndPeriod(Phprojekt_Auth::getRealUser(), $start, $end);
-        if (empty($contracts)) {
-            echo Zend_Json::encode(array('minutesToWork' => 0));
-            return;
-        }
-
         $minutesPerDay = $this->_contractsToMinutesPerDay($contracts, $start, $end);
         $minutesPerDay = $this->_applyHolidayWeights($minutesPerDay, $start, $end);
 

--- a/phprojekt/application/Timecard/Models/Contract.php
+++ b/phprojekt/application/Timecard/Models/Contract.php
@@ -39,7 +39,7 @@ class Timecard_Models_Contract extends Phprojekt_ActiveRecord_Abstract
         }
 
         if (empty($contractIds)) {
-            return array();
+            throw new Phprojekt_Exception_ContractNotSet();
         }
 
         $contractsById = array();

--- a/phprojekt/htdocs/phpr/StatisticsView.js
+++ b/phprojekt/htdocs/phpr/StatisticsView.js
@@ -52,7 +52,9 @@ define([
                 }
 
                 this.overtimeLabel.innerHTML = minus + text.join(" ") + " Overtime";
-            }));
+            }), function(err) {
+                api.defaultErrorHandler(err);
+            });
         },
 
         _renderData: function(data) {

--- a/phprojekt/library/Phprojekt/Exception/ContractNotSet.php
+++ b/phprojekt/library/Phprojekt/Exception/ContractNotSet.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 3 as published by the Free Software Foundation
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * @copyright  Copyright (c) 2013 Mayflower GmbH (http://www.mayflower.de)
+ * @license    LGPL v3 (See LICENSE file)
+ */
+
+/**
+ * Exception thrown when a user doesn't have an associated contract.
+ */
+class Phprojekt_Exception_ContractNotSet extends Phprojekt_Exception_Published
+{
+    protected $_type     = 'contractNotSet';
+    protected $_httpCode = 500;
+
+    public function __construct()
+    {
+        parent::__construct("You don't have an associated contract.");
+    }
+}


### PR DESCRIPTION
In case the user doesn't have a contract we need to find a way to make
sure he knows about this and can fix it. Therefore we cannot just
return 0 as this is not a special case. There might be contracts (e.g.
freelancers) that will have a 0h contract.
