### PR TITLE
Avoid declaring variables in global scope

### DIFF
--- a/phprojekt/htdocs/phpr/StatisticsView.js
+++ b/phprojekt/htdocs/phpr/StatisticsView.js
@@ -61,7 +61,7 @@ define([
                 maxMinutes = 1000,
                 minutesToWork = 450,
                 displayHeight = domAttr.get(this.bookedTimePerDayGraph, "height"),
-                heightForTimebars = displayHeight;
+                heightForTimebars = displayHeight,
                 heightPerMinute = heightForTimebars / maxMinutes,
                 displayWidth = domAttr.get(this.bookedTimePerDayGraph, "width"),
                 barPadding = 2,


### PR DESCRIPTION
The semicolon instead of a comma causes the variables after it to be declared
in global scope.
