### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - P6_TEST_CONFIG=configuration-travis.php
 before_script:
     - (cd phprojekt && wget http://getcomposer.org/composer.phar)
-    - (cd phprojekt && php composer.phar install --no-interaction --no-progress --dev)
+    - (cd phprojekt && php composer.phar install --prefer-source --no-interaction --no-progress --dev)
     - mysql -u root -e 'create database `phprojekt-test-memory`'
     - mysql -u root phprojekt-test-memory < phprojekt/tests/test_database_memory.sql
 


### PR DESCRIPTION
prefer-source in composer in .travis.yml so that it uses git

Travis is thrashing the github api, which causes transport errors when
composer tries to get packages from it. By specifying --prefer-source,
composer should use git instead of the github api, which should stop our
builds from failing.

See https://github.com/travis-ci/travis-core/issues/186
