### PR TITLE
Use complete month range when generating statistics

### DIFF
--- a/phprojekt/htdocs/phpr/Statistics/WorktimeMonthGraph.js
+++ b/phprojekt/htdocs/phpr/Statistics/WorktimeMonthGraph.js
@@ -277,7 +277,10 @@ define([
         },
 
         _getModelParams: function() {
-            return { projects: this.projects };
+            var end = new Date();
+            end.setDate(1);
+            end.setMonth(end.getMonth() + 1);
+            return { projects: this.projects, end: end };
         }
     });
 });


### PR DESCRIPTION
Per default our range for the timecard calls is from the first of the month
to the current date. This works fine for calculating the overtime, etc. To
correctly generate the statistics for the whole month we need to get all
days of the current month. Therefore we define the end date manually.
